### PR TITLE
Fixing typo in push_host of gemspec

### DIFF
--- a/jfrog-saas-log-collector.gemspec
+++ b/jfrog-saas-log-collector.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license = 'MIT'
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.metadata['allowed_push_host'] = "Set to your gem server 'https://rubygems.org'"
+  spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
   spec.metadata['homepage_uri'] = 'https://github.com/jfrog/jfrog-saas-log-collector/wiki'
   spec.metadata['source_code_uri'] = 'https://github.com/jfrog/jfrog-saas-log-collector'


### PR DESCRIPTION
Fixing typo in push_host of gemspec